### PR TITLE
Don't use unsupported JavaScript array comprehension

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -109,7 +109,10 @@ export default {
               continue;
             }
 
-            var matches = [for (x of patterns) if (line.match(x.regex)) x.cb(line.match(x.regex))];
+            var matches = patterns.map((x) => {
+              const match = line.match(x.regex)
+              return match ? x.cb(match) : null
+            })
             var match = matches[0];
             var lineNo = parseInt(match.lineNo) - 1;
             var message = match.text;


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!