### PR TITLE
Ignore non-zero exit code

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -92,7 +92,7 @@ export default {
 
         args.push(filePath);
 
-        return helpers.exec(this.executablePath, args).then(result => {
+        return helpers.exec(this.executablePath, args, {ignoreExitCode: true}).then(result => {
           const toReturn = [];
           const patterns = [
             {regex: /(.+):(\d+):\s(.+)/, cb: m => {


### PR DESCRIPTION
Ignore non-zero exit code from `erlc` since it does not mean that `erlc` failed, instead it means that an error was found in the file checked by the linter.