### PR TITLE
Display errors without line

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -91,6 +91,9 @@ export default {
               const match = line.match(x.regex);
               return match ? x.cb(match) : null;
             });
+            if (lineMatches[0] === null && lineMatches[1] !== null) {
+              return lineMatches[1];
+            }
             return lineMatches[0];
           });
           const toReturn = matches.reduce((results, match) => {


### PR DESCRIPTION
Display errors without specific line, like the error "Module name does not match file name".

Closes #41